### PR TITLE
Separate Newton and PCD parts for nonlinear problems

### DIFF
--- a/demo/defcon/navier-stokes.py
+++ b/demo/defcon/navier-stokes.py
@@ -27,7 +27,7 @@ from dolfin import *
 from matplotlib import pyplot
 
 from fenapack import PCDKSP
-from fenapack import PCDProblem
+from fenapack import PCDAssembler
 from fenapack import StabilizationParameterSD
 
 import sys
@@ -132,9 +132,9 @@ class NavierStokesProblem(BifurcationProblem):
             bc_pcd = DirichletBC(z.function_space().sub(1), 0.0, colours, 2)
 
         # Store what needed for later
-        self._pcd_problem = PCDProblem(F, bcs, J, J_pc,
-                                       ap=ap, kp=kp, mp=mp,
-                                       bcs_pcd=bc_pcd)
+        self._pcd_assembler = PCDAssembler(J, F, bcs, J_pc,
+                                           ap=ap, kp=kp, mp=mp,
+                                           bcs_pcd=bc_pcd)
 
         return F
 
@@ -270,7 +270,7 @@ class NavierStokesProblem(BifurcationProblem):
         x = as_backend_type(problem.u.vector()).vec()
         # FIXME: Make sure this works when J_pc is not used
         solver.jacobian(solver.snes, x, *solver.snes.ksp.getOperators())
-        ksp.init_pcd(self._pcd_problem)
+        ksp.init_pcd(self._pcd_assembler)
 
         return solver
 

--- a/demo/navier-stokes-pcd/demo_navier-stokes-pcd.py
+++ b/demo/navier-stokes-pcd/demo_navier-stokes-pcd.py
@@ -25,8 +25,8 @@ from dolfin import *
 from matplotlib import pyplot
 
 from fenapack import PCDKrylovSolver
-from fenapack import PCDNewtonSolver
-from fenapack import PCDProblem
+from fenapack import PCDAssembler
+from fenapack import PCDNewtonSolver, PCDNonlinearProblem
 from fenapack import StabilizationParameterSD
 
 import argparse, sys, os
@@ -138,7 +138,9 @@ if args.pcd_variant == "BRM2":
     #kp -= Constant(1.0/nu)*dot(u_, n)*p*q*ds(0)  # TODO: Is this beneficial?
 
 # Collect forms to define nonlinear problem
-problem = PCDProblem(F, [bc0, bc1], J, J_pc, ap=ap, kp=kp, mp=mp, bcs_pcd=bc_pcd)
+pcd_assembler = PCDAssembler(J, F, [bc0, bc1],
+                             J_pc, ap=ap, kp=kp, mp=mp, bcs_pcd=bc_pcd)
+problem = PCDNonlinearProblem(pcd_assembler)
 
 # Set up linear solver (GMRES with right preconditioning using Schur fact)
 linear_solver = PCDKrylovSolver(comm=mesh.mpi_comm())

--- a/demo/navier-stokes-pcd/documentation.rst
+++ b/demo/navier-stokes-pcd/documentation.rst
@@ -85,7 +85,7 @@ preparing the preconditioner.
 and Laplacian ``ap`` to be used by :any:`PCD BRM preconditioner
 <fenapack.preconditioners.PCDPC_BRM>` are defined using pressure components
 ``p``, ``q`` on the mixed space ``W``. They are passed to the class
-:py:class:`fenapack.nonlinear_solvers.PCDProblem` which takes care of
+:py:class:`fenapack.assembling.PCDAssembler` which takes care of
 assembling the operators on demand.
 
 .. code-block:: python
@@ -100,7 +100,9 @@ assembling the operators on demand.
         kp -= Constant(1.0/nu)*dot(u_, n)*p*q*ds(1)
 
     # Collect forms to define nonlinear problem
-    problem = PCDProblem(F, [bc0, bc1], J, J_pc, ap=ap, kp=kp, mp=mp, bcs_pcd=bc_pcd)
+    pcd_assembler = PCDAssembler(J, F, [bc0, bc1],
+                                 J_pc, ap=ap, kp=kp, mp=mp, bcs_pcd=bc_pcd)
+    problem = PCDNonlinearProblem(pcd_assembler)
 
 Now we create GMRES preconditioned with PCD, set the tolerance, enable
 monitoring of residual during Krylov iterarations, and set the maximal

--- a/fenapack/__init__.py
+++ b/fenapack/__init__.py
@@ -33,6 +33,7 @@ del SubSystemsManager, PETSc
 
 # Import public API
 from fenapack.field_split import PCDKSP, PCDKrylovSolver
-from fenapack.nonlinear_solvers import PCDNewtonSolver, PCDProblem
+from fenapack.assembling import PCDProblem
+from fenapack.nonlinear_solvers import PCDNewtonSolver, PCDNonlinearProblem
 from fenapack.preconditioners import PCDPC_BRM1, PCDPC_BRM2
 from fenapack.stabilization import StabilizationParameterSD

--- a/fenapack/__init__.py
+++ b/fenapack/__init__.py
@@ -33,7 +33,7 @@ del SubSystemsManager, PETSc
 
 # Import public API
 from fenapack.field_split import PCDKSP, PCDKrylovSolver
-from fenapack.assembling import PCDProblem
+from fenapack.assembling import PCDAssembler
 from fenapack.nonlinear_solvers import PCDNewtonSolver, PCDNonlinearProblem
 from fenapack.preconditioners import PCDPC_BRM1, PCDPC_BRM2
 from fenapack.stabilization import StabilizationParameterSD

--- a/fenapack/assembling.py
+++ b/fenapack/assembling.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2015-2018 Jan Blechta and Martin Rehor
+#
+# This file is part of FENaPack.
+#
+# FENaPack is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FENaPack is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with FENaPack.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides wrappers for assembling systems of linear algebraic
+equations to be solved with the use of PCD preconditioning strategy.
+These wrappers naturally provide routines for assembling preconditioning
+operators themselves.
+"""
+
+from dolfin import SystemAssembler, assemble
+
+
+class PCDProblem(object):
+    """Base class for creating linear problems to be solved by application
+    of the PCD preconditioning strategy. Users are encouraged to use this class
+    for interfacing with :py:class:`fenapack.field_split.PCDKrylovSolver`.
+    On request it assembles not only the individual PCD operators but also the
+    system matrix and the right hand side vector defining the linear problem.
+    """
+
+    def __init__(self, a, L, bcs, a_pc=None,
+                 mp=None, mu=None, ap=None, fp=None, kp=None, bcs_pcd=[]):
+        """Collect individual variational forms and boundary conditions
+        defining a linear problem (system matrix + RHS vector) on the one side
+        and preconditioning operators on the other side.
+
+        *Arguments*
+            a (:py:class:`dolfin.Form` or :py:class:`ufl.Form`)
+                Bilinear form representing a system matrix.
+            L (:py:class:`dolfin.Form` or :py:class:`ufl.Form`)
+                Linear form representing a right hand side vector.
+            bcs (:py:class:`list` of :py:class:`dolfin.DirichletBC`)
+                Boundary conditions applied to ``a``, ``L``, and ``a_pc``.
+            a_pc (:py:class:`dolfin.Form` or :py:class:`ufl.Form`)
+                Bilinear form representing a matrix optionally passed to
+                preconditioner instead of ``a``. In case of PCD, stabilized
+                00-block can be passed to 00-KSP solver.
+            mp, mu, ap, fp, kp (:py:class:`dolfin.Form` or :py:class:`ufl.Form`)
+                Bilinear forms which (some of them) might be used by a
+                particular PCD preconditioner. Typically they represent "mass
+                matrix" on pressure, "mass matrix" on velocity, minus Laplacian
+                operator on pressure, pressure convection-diffusion operator,
+                and pressure convection operator respectively.
+            bcs_pcd (:py:class:`list` of :py:class:`dolfin.DirichletBC`)
+                Artificial boundary conditions used by PCD preconditioner.
+
+        All the arguments should be given on the common mixed function space.
+        """
+
+        # Assembler for the linear system of algebraic equations
+        self.assembler = SystemAssembler(a, L, bcs)
+
+        # Assembler for preconditioner
+        if a_pc is not None:
+            self.assembler_pc = SystemAssembler(a_pc, L, bcs)
+        else:
+            self.assembler_pc = None
+
+        # Store forms/bcs for later use
+        self.forms = {
+            "L": L,
+            "ap": ap,
+            "mp": mp,
+            "mu": mu,
+            "fp": fp,
+            "kp": kp,
+        }
+        self._bcs_pcd = bcs_pcd
+
+
+    def get_form(self, key):
+        form = self.forms.get(key)
+        if form is None:
+            raise AttributeError("Form '%s' requested by PCD not available" % key)
+        return form
+
+
+    def function_space(self):
+        return self.forms["L"].arguments()[0].function_space()
+
+
+    def rhs_vector(self, b, x=None):
+        """Assemble right hand side vector ``b``.
+
+        The version with ``x`` is suitable for use inside
+        a (quasi)-Newton solver.
+        """
+        if x is not None:
+            self.assembler.assemble(b, x)
+        else:
+            self.assembler.assemble(b)
+
+    def system_matrix(self, A):
+        """Assemble system matrix ``A``."""
+        self.assembler.assemble(A)
+
+
+    def pc_matrix(self, P):
+        """Assemble preconditioning matrix ``P`` whose relevant blocks can be
+        passed to actual parts of the ``KSP`` solver.
+        """
+        if self.assembler_pc is not None:
+            self.assembler_pc.assemble(P)
+
+
+    def ap(self, Ap):
+        assembler = SystemAssembler(self.get_form("ap"), self.get_form("L"),
+                                    self.pcd_bcs())
+        assembler.assemble(Ap)
+
+
+    def mp(self, Mp):
+        assemble(self.get_form("mp"), tensor=Mp)
+
+
+    def mu(self, Mu):
+        assemble(self.get_form("mu"), tensor=Mu)
+
+
+    def fp(self, Fp):
+        assemble(self.get_form("fp"), tensor=Fp)
+
+
+    def kp(self, Kp):
+        assemble(self.get_form("kp"), tensor=Kp)
+
+
+    # FIXME: Naming
+    def pcd_bcs(self):
+        try:
+            assert self._bcs_pcd is not None
+        except (AttributeError, AssertionError):
+            raise AttributeError("BCs requested by PCD not available")
+        return self._bcs_pcd

--- a/fenapack/assembling.py
+++ b/fenapack/assembling.py
@@ -24,7 +24,7 @@ operators themselves.
 from dolfin import SystemAssembler, assemble
 
 
-class PCDProblem(object):
+class PCDAssembler(object):
     """Base class for creating linear problems to be solved by application
     of the PCD preconditioning strategy. Users are encouraged to use this class
     for interfacing with :py:class:`fenapack.field_split.PCDKrylovSolver`.

--- a/fenapack/field_split.py
+++ b/fenapack/field_split.py
@@ -56,8 +56,8 @@ class PCDKSP(PETSc.KSP):
 
 
     @allow_only_one_call
-    def init_pcd(self, pcd_problem, pcd_pc_class=None):
-        """Initialize from ``PCDProblem`` instance. Needs to be called
+    def init_pcd(self, pcd_assembler, pcd_pc_class=None):
+        """Initialize from ``PCDAssembler`` instance. Needs to be called
         after ``setOperators`` and ``setUp``. That's why two-phase
         initialization is needed: first ``__init__``, then ``init_pcd``
 
@@ -66,7 +66,7 @@ class PCDKSP(PETSc.KSP):
         """
 
         # Get subfield index sets
-        V = pcd_problem.function_space()
+        V = pcd_assembler.function_space()
         is0 = dofmap_dofs_is(V.sub(0).dofmap())
         is1 = dofmap_dofs_is(V.sub(1).dofmap())
 
@@ -119,19 +119,19 @@ class PCDKSP(PETSc.KSP):
             ksp1.pc.setPythonContext(pcd_pc)
             ksp1.setFromOptions()  # Override defaults above by user's options
 
-        # Get backend implementation of PCDProblem
+        # Get backend implementation of PCDAssembler
         # FIXME: Make me parameter
         #deep_submats = False
         deep_submats = True
-        pcd_interface = PCDInterface(pcd_problem, is0, is1,
+        pcd_interface = PCDInterface(pcd_assembler, is0, is1,
                                      deep_submats=deep_submats)
 
         # Provide assembling routines to PCD
         try:
             pcd_pc.init_pcd(pcd_interface)
         except Exception:
-            print("Initialization of PCD PC from PCDProblem failed!")
-            print("Maybe wrong PCD PC class or PCDProblem instance.")
+            print("Initialization of PCD PC from PCDAssembler failed!")
+            print("Maybe wrong PCD PC class or PCDAssembler instance.")
             raise
 
         # Setup PCD PC so that we have accurate timing
@@ -157,15 +157,15 @@ class PCDKrylovSolver(PETScKrylovSolver):
         super(PCDKrylovSolver, self).__init__(self._ksp)
 
 
-    def init_pcd(self, pcd_problem, pcd_pc_class=None):
-        """Initialize from ``PCDProblem`` instance. Needs to be called
+    def init_pcd(self, pcd_assembler, pcd_pc_class=None):
+        """Initialize from ``PCDAssembler`` instance. Needs to be called
         after ``setOperators`` and ``setUp``. That's why two-phase
         initialization is needed: first ``__init__``, then ``init_pcd``
 
         Note that this function automatically calls setFromOptions to
         all subKSP objects.
         """
-        self._ksp.init_pcd(pcd_problem, pcd_pc_class=pcd_pc_class)
+        self._ksp.init_pcd(pcd_assembler, pcd_pc_class=pcd_pc_class)
 
 
     def ksp(self):

--- a/test/bench/test_pcd_scaling.py
+++ b/test/bench/test_pcd_scaling.py
@@ -13,6 +13,7 @@ import itertools
 from fenapack import PCDKrylovSolver
 from fenapack import PCDNewtonSolver
 from fenapack import PCDProblem
+from fenapack import PCDNonlinearProblem
 from fenapack import StabilizationParameterSD
 
 
@@ -139,8 +140,11 @@ def create_pcd_problem(F, bcs, J, J_pc, w, nu, boundary_markers, pcd_variant):
         kp -= Constant(1.0/nu)*dot(u_, n)*p*q*ds(1)
         #kp -= Constant(1.0/nu)*dot(u_, n)*p*q*ds(0)  # TODO: Is this beneficial?
 
-    # Collect forms to define nonlinear problem
-    problem = PCDProblem(F, bcs, J, J_pc, ap=ap, kp=kp, mp=mp, bcs_pcd=bc_pcd)
+    # Collect forms to define PCD problem
+    pcd_problem = PCDProblem(J, F, bcs, J_pc, ap=ap, kp=kp, mp=mp, bcs_pcd=bc_pcd)
+
+    # Create corresponding nonlinear problem
+    problem = PCDNonlinearProblem(pcd_problem)
 
     return problem
 

--- a/test/bench/test_pcd_scaling.py
+++ b/test/bench/test_pcd_scaling.py
@@ -11,9 +11,8 @@ import gc
 import itertools
 
 from fenapack import PCDKrylovSolver
-from fenapack import PCDNewtonSolver
-from fenapack import PCDProblem
-from fenapack import PCDNonlinearProblem
+from fenapack import PCDAssembler
+from fenapack import PCDNewtonSolver, PCDNonlinearProblem
 from fenapack import StabilizationParameterSD
 
 
@@ -140,11 +139,11 @@ def create_pcd_problem(F, bcs, J, J_pc, w, nu, boundary_markers, pcd_variant):
         kp -= Constant(1.0/nu)*dot(u_, n)*p*q*ds(1)
         #kp -= Constant(1.0/nu)*dot(u_, n)*p*q*ds(0)  # TODO: Is this beneficial?
 
-    # Collect forms to define PCD problem
-    pcd_problem = PCDProblem(J, F, bcs, J_pc, ap=ap, kp=kp, mp=mp, bcs_pcd=bc_pcd)
+    # Collect forms in PCD assembler
+    pcd_assembler = PCDAssembler(J, F, bcs, J_pc, ap=ap, kp=kp, mp=mp, bcs_pcd=bc_pcd)
 
-    # Create corresponding nonlinear problem
-    problem = PCDNonlinearProblem(pcd_problem)
+    # Create nonlinear problem
+    problem = PCDNonlinearProblem(pcd_assembler)
 
     return problem
 
@@ -198,11 +197,11 @@ def create_solver(comm, pcd_variant, ls, mumps_debug=False):
 @pytest.mark.parametrize("pcd_variant", ["BRM1", "BRM2"])
 @pytest.mark.parametrize("ls",          ["direct", "iterative"])
 def test_scaling_mesh(nu, alpha, nls, pcd_variant, ls, postprocessor):
-    set_log_level(WARNING)
+    #set_log_level(WARNING)
 
     # Iterate over refinement level
     #for level in range(7):
-    for level in range(6):
+    for level in range(4):
 
         # Prepare problem and solvers
         with Timer("Prepare") as t_prepare:

--- a/test/bench/test_pcd_scaling.py
+++ b/test/bench/test_pcd_scaling.py
@@ -197,11 +197,11 @@ def create_solver(comm, pcd_variant, ls, mumps_debug=False):
 @pytest.mark.parametrize("pcd_variant", ["BRM1", "BRM2"])
 @pytest.mark.parametrize("ls",          ["direct", "iterative"])
 def test_scaling_mesh(nu, alpha, nls, pcd_variant, ls, postprocessor):
-    #set_log_level(WARNING)
+    set_log_level(WARNING)
 
     # Iterate over refinement level
     #for level in range(7):
-    for level in range(4):
+    for level in range(6):
 
         # Prepare problem and solvers
         with Timer("Prepare") as t_prepare:

--- a/test/unit/test_fieldsplit.py
+++ b/test/unit/test_fieldsplit.py
@@ -14,10 +14,15 @@ from bench.test_pcd_scaling import get_random_string
 
 def create_dummy_solver_and_problem():
     mesh = UnitSquareMesh(3, 3)
+    class Gamma1(SubDomain):
+        def inside(self, x, on_boundary):
+            return on_boundary and near(x[0], 0.0)
     P2 = VectorElement("Lagrange", mesh.ufl_cell(), 2)
     P1 = FiniteElement("Lagrange", mesh.ufl_cell(), 1)
     W = FunctionSpace(mesh, P2*P1)
     ff = MeshFunction('size_t', W.mesh(), W.mesh().topology().dim()-1)
+    ff.set_all(0)
+    Gamma1().mark(ff, 1)
     w = Function(W)
     F, bcs, J, J_pc = create_forms(w, ff, 1.0, 1.0, "newton", "direct")
     problem = create_pcd_problem(F, bcs, J, J_pc, w, 1.0, ff, "BRM1")


### PR DESCRIPTION
The class `PCDProblem`, responsible for assembling (not only) PCD operators, has been changed to `PCDAssembler` which is adapted to a general linear problem we want to solve with PCD strategy. 

The new class `PCDNonlinearProblem` wraps `PCDAssembler` and recasts some of its methods to those required by DOLFIN's `NonlinearProblem` (i.e. `F` and `J`).