### PR TITLE
Specification of form properties on the high level

### DIFF
--- a/fenapack/__init__.py
+++ b/fenapack/__init__.py
@@ -33,7 +33,7 @@ del SubSystemsManager, PETSc
 
 # Import public API
 from fenapack.field_split import PCDKSP, PCDKrylovSolver
-from fenapack.assembling import PCDAssembler
+from fenapack.assembling import PCDAssembler, PCDForm
 from fenapack.nonlinear_solvers import PCDNewtonSolver, PCDNonlinearProblem
 from fenapack.preconditioners import PCDPC_BRM1, PCDPC_BRM2
 from fenapack.stabilization import StabilizationParameterSD

--- a/fenapack/assembling.py
+++ b/fenapack/assembling.py
@@ -144,7 +144,6 @@ class PCDAssembler(object):
 
 
     def mp(self, Mp):
-        mp = self.get_dolfin_form("mp")
         assemble(self.get_dolfin_form("mp"), tensor=Mp)
 
 

--- a/fenapack/assembling.py
+++ b/fenapack/assembling.py
@@ -169,9 +169,9 @@ class PCDAssembler(object):
 
 
 class PCDForm(object):
-    """Wrapper for PCD operators represented by :py:class:`Form`.
-    This class allows to record specific properties of the form that can be
-    utilized later while setting up the preconditioner.
+    """Wrapper for PCD operators represented by :py:class:`dolfin.Form` or
+    :py:class:`ufl.Form`. This class allows to record specific properties of
+    the form that can be utilized later while setting up the preconditioner.
 
     For example, we can specify which matrices remain constant during the outer
     iterative algorithm (e.g. Newton-Raphson method, time-stepping) and which

--- a/fenapack/field_split_backend.py
+++ b/fenapack/field_split_backend.py
@@ -132,7 +132,7 @@ class PCDInterface(object):
                                                   can_be_destroyed=destruction,
                                                   can_be_shared=True)
             assemble_func(dolfin_mat)
-            mat = self._get_deep_submat(dolfin_mat.mat(), iset, submat=None)
+            mat = self._get_deep_submat(dolfin_mat, iset, submat=None)
             # NOTE: shallow version results in PETSc error 92 [MatGetFactor() failed]
 
             # Use eventual spd flag

--- a/fenapack/field_split_backend.py
+++ b/fenapack/field_split_backend.py
@@ -76,13 +76,15 @@ class PCDInterface(object):
     def setup_mat_Kp(self, mat=None):
         """Setup and assemble pressure convection
         matrix and return it"""
-        return self.assemble_operator(self.assembler.kp, self.is_p, submat=mat)
+        if mat is None or not self.assembler.get_pcd_form("kp").is_constant():
+            return self.assemble_operator(self.assembler.kp, self.is_p, submat=mat)
 
 
     def setup_mat_Fp(self, mat=None):
         """Setup and assemble pressure convection-diffusion
         matrix and return it"""
-        return self.assemble_operator(self.assembler.fp, self.is_p, submat=mat)
+        if mat is None or not self.assembler.get_pcd_form("kp").is_constant():
+            return self.assemble_operator(self.assembler.fp, self.is_p, submat=mat)
 
 
     def apply_pcd_bcs(self, vec):

--- a/fenapack/field_split_backend.py
+++ b/fenapack/field_split_backend.py
@@ -133,7 +133,6 @@ class PCDInterface(object):
                                                   can_be_shared=True)
             assemble_func(dolfin_mat)
             mat = self._get_deep_submat(dolfin_mat, iset, submat=None)
-            # NOTE: shallow version results in PETSc error 92 [MatGetFactor() failed]
 
             # Use eventual spd flag
             mat.setOption(PETSc.Mat.Option.SPD, spd)
@@ -145,12 +144,12 @@ class PCDInterface(object):
             ksp.setOperators(mat, mat)
             assert ksp.getOperators()[0].isAssembled()
 
-            # Setup ksp
+            # Set up ksp
             with Timer("FENaPack: {} setup".format(prefix)):
                 ksp.setUp()
+
         elif not const:
-            # Reinitialize matrix and ksp
-            # TODO: Can we use a virtual submat (view into dolfin mat) in KSP?
+            # Assemble matrix and set up ksp
             mat = self._assemble_operator_deep(assemble_func, iset, submat=mat)
             assert mat.getOptionsPrefix() == prefix
             ksp.setOperators(mat, mat)

--- a/fenapack/field_split_backend.py
+++ b/fenapack/field_split_backend.py
@@ -132,9 +132,8 @@ class PCDInterface(object):
                                                   can_be_destroyed=destruction,
                                                   can_be_shared=True)
             assemble_func(dolfin_mat)
-            mat = self._get_deep_submat(dolfin_mat, iset, submat=None)
-            # NOTE: self._get_shallow_submat(dolfin_mat, iset, submat=None)
-            #       results in PETSc error code 92 [MatGetFactor() failed]
+            mat = self._get_deep_submat(dolfin_mat.mat(), iset, submat=None)
+            # NOTE: shallow version results in PETSc error 92 [MatGetFactor() failed]
 
             # Use eventual spd flag
             mat.setOption(PETSc.Mat.Option.SPD, spd)

--- a/fenapack/field_split_backend.py
+++ b/fenapack/field_split_backend.py
@@ -83,7 +83,7 @@ class PCDInterface(object):
     def setup_mat_Fp(self, mat=None):
         """Setup and assemble pressure convection-diffusion
         matrix and return it"""
-        if mat is None or not self.assembler.get_pcd_form("kp").is_constant():
+        if mat is None or not self.assembler.get_pcd_form("fp").is_constant():
             return self.assemble_operator(self.assembler.fp, self.is_p, submat=mat)
 
 

--- a/fenapack/preconditioners.py
+++ b/fenapack/preconditioners.py
@@ -68,12 +68,9 @@ class BasePCDPC(object):
 
 
     def setUp(self, pc):
-
         # Prepare mass matrix and Laplacian solvers
         # NOTE: Called function ensures that assembly, submat extraction and
         #       ksp setup is done only once during preconditioner lifetime.
-        # FIXME: Maybe move Mp and Ap setup to init and remove logic in backend.
-        #        This will make it obvious that this is done once.
         self.interface.setup_ksp_Mp(self.ksp_Mp)
         self.interface.setup_ksp_Ap(self.ksp_Ap)
 
@@ -137,7 +134,7 @@ class PCDPC_BRM1(BasePCDPC):
 
 
 class PCDPC_BRM2(BasePCDPC):
-    """This class implements a modification steady variant of PCD
+    """This class implements a modification of steady variant of PCD
     described in [2]_.
 
     .. [2] Elman H. C., Silvester D. J., Wathen A. J., *Finite Elements and Fast

--- a/fenapack/preconditioners.py
+++ b/fenapack/preconditioners.py
@@ -75,8 +75,10 @@ class BasePCDPC(object):
         self.interface.setup_ksp_Ap(self.ksp_Ap)
 
         # Prepare convection matrix
-        self.mat_Kp = self.interface.setup_mat_Kp(mat=getattr(self, "mat_Kp", None))
-        self.mat_Kp.setOptionsPrefix(pc.getOptionsPrefix() + "PCD_Kp_")
+        Kp = self.interface.setup_mat_Kp(mat=getattr(self, "mat_Kp", None))
+        if Kp is not None: # updated only if not constant
+            self.mat_Kp = Kp
+            self.mat_Kp.setOptionsPrefix(pc.getOptionsPrefix() + "PCD_Kp_")
 
         # Fetch bcs apply function
         self.bcs_applier = self.interface.apply_pcd_bcs


### PR DESCRIPTION
It is possible to decide whether forms used to assemble PCD operators are constant or not immediately after collecting them inside `PCDAssembler`. 